### PR TITLE
Service env attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ SOGOU_USERNAME="YOUR SOGOU USERNAME"
 SOGOU_PASSWORD="YOUR SOGOU PASSWORD"
 ```
 
+### Env
+
+There are two ways to set the environment. One is `ENV['ENV']` environment variable. Another is service attribute.
+If service attribute is set, environment variable will be ignored.
+
+```ruby
+account = Service::Account.new
+account.env = 'production'
+```
+
 ## Logging
 
 The client includes a `Logger` instance that can be used to capture debugging information.

--- a/lib/sogou/search/api/core/base_service.rb
+++ b/lib/sogou/search/api/core/base_service.rb
@@ -9,6 +9,7 @@ module Sogou
         class BaseService
           attr_accessor :authorization
           attr_accessor :client_options
+          attr_accessor :env
 
           def initialize(service)
             @url = "http://#{service_host}/sem/sms/v1/#{service}?wsdl"
@@ -50,7 +51,11 @@ module Sogou
           private
 
           def service_host
-            "api.agent.sogou.com#{ENV.fetch('ENV', 'development') == 'development' ? ':8080' : ''}"
+            "api.agent.sogou.com#{environment == 'development' ? ':8080' : ''}"
+          end
+
+          def environment
+            @env ||= ENV.fetch('ENV', 'development')
           end
         end
       end

--- a/lib/sogou/search/api/version.rb
+++ b/lib/sogou/search/api/version.rb
@@ -1,7 +1,7 @@
 module Sogou
   module Search
     module Api
-      VERSION = '1.0.0'
+      VERSION = '2.0.0'
 
       OS_VERSION = begin
         if RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/

--- a/sogou-search-api.gemspec
+++ b/sogou-search-api.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.11'
   spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'gem-release', '~> 2.2'
 end

--- a/sogou-search-api.gemspec
+++ b/sogou-search-api.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.11'
   spec.add_development_dependency 'simplecov', '~> 0.21'
-  spec.add_development_dependency 'gem-release', '~> 2.2'
 end

--- a/sogou-search-api.gemspec
+++ b/sogou-search-api.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'savon', '~> 2.12'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'simplecov', '~> 0.14'
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.11'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
 end

--- a/spec/sogou/search/api/core/base_service_spec.rb
+++ b/spec/sogou/search/api/core/base_service_spec.rb
@@ -68,5 +68,14 @@ describe Core::BaseService do
 
       it { expect(service_host).to eq('api.agent.sogou.com') }
     end
+
+    context 'with preset env' do
+      before(:each) do
+        ENV['ENV'] = 'production'
+        this.env = 'development'
+      end
+
+      it { expect(service_host).to eq('api.agent.sogou.com:8080') }
+    end
   end
 end


### PR DESCRIPTION
* Adds the ability to set environment via service attribute instead of an environment variable.
* Adds [gem-release](https://github.com/svenfuchs/gem-release) to the dev dependencies to simplify releasing
* Updates README.md with `env` instructions
* Updates dev dependencies
