### PR TITLE
Fix base service url generation

### DIFF
--- a/lib/sogou/search/api/core/base_service.rb
+++ b/lib/sogou/search/api/core/base_service.rb
@@ -12,7 +12,7 @@ module Sogou
           attr_accessor :env
 
           def initialize(service)
-            @url = "http://#{service_host}/sem/sms/v1/#{service}?wsdl"
+            @service = service
             @client_options = ClientOptions.default.dup
           end
 
@@ -31,7 +31,7 @@ module Sogou
 
           def client
             @client ||= Savon::Client.new do |savon|
-              savon.wsdl(@url)
+              savon.wsdl(url)
               savon.pretty_print_xml(true)
               savon.namespaces('xmlns:v1' => 'http://api.sogou.com/sem/common/v1')
               savon.env_namespace(:soapenv)
@@ -49,6 +49,10 @@ module Sogou
           end
 
           private
+
+          def url
+            "http://#{service_host}/sem/sms/v1/#{@service}?wsdl"
+          end
 
           def service_host
             "api.agent.sogou.com#{environment == 'development' ? ':8080' : ''}"

--- a/lib/sogou/search/api/version.rb
+++ b/lib/sogou/search/api/version.rb
@@ -1,7 +1,7 @@
 module Sogou
   module Search
     module Api
-      VERSION = '2.0.0'
+      VERSION = '2.0.1'
 
       OS_VERSION = begin
         if RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/

--- a/spec/sogou/search/api/core/base_service_spec.rb
+++ b/spec/sogou/search/api/core/base_service_spec.rb
@@ -28,6 +28,16 @@ describe Core::BaseService do
     context 'without options' do
       it { expect(client).to be_a_kind_of(Savon::Client) }
 
+      it 'sets the right wsdl for development environment' do
+        this.instance_variable_set(:@env, 'development')
+        expect(client.wsdl.document).to eq("http://api.agent.sogou.com:8080/sem/sms/v1/foo?wsdl")
+      end
+
+      it 'sets the right wsdl for production environment' do
+        this.instance_variable_set(:@env, 'production')
+        expect(client.wsdl.document).to eq("http://api.agent.sogou.com/sem/sms/v1/foo?wsdl")
+      end
+
       context ', no authorization' do
         it { expect(client.globals[:soap_header]).to eq({}) }
       end


### PR DESCRIPTION
Since we have `@url` generation in the initializer, setting environment for an instance didn't affect URL generation